### PR TITLE
chore: aggressively group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,14 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+      patch-and-minor:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
- all dev deps in one group
- all production patch and minor updates in one group
- production major updates are still in individual PRs